### PR TITLE
Fixes for recent versions of pyusb

### DIFF
--- a/src/gnome15/g15devices.py
+++ b/src/gnome15/g15devices.py
@@ -427,10 +427,11 @@ device_added_listeners = []
 device_removed_listeners = []
     
 def __device_added(observer, device):
-    if "uevent" in device.attributes:
-        uevent = g15pythonlang.parse_as_properties(device.attributes["uevent"])
+    uevent_attr = device.attributes.get('uevent', None)
+    if uevent_attr != None:
+        uevent = g15pythonlang.parse_as_properties(uevent_attr)
         if "PRODUCT" in uevent:
-            if "subsystem" in device.attributes and device.attributes["subsystem"] == "usb":
+            if device.attributes.get("subsystem", None) == "usb":
                 major,minor,_ = uevent["PRODUCT"].split("/")
             else:
                 _,major,minor,_ = uevent["PRODUCT"].split("/")

--- a/src/pylibg19/g19/g19.py
+++ b/src/pylibg19/g19/g19.py
@@ -371,10 +371,10 @@ class G19UsbController(object):
         #self.handleIf1.setConfiguration(1)
         
         logger.debug("Claiming LCD interface")
-        self.handleIf0.claimInterface(display_interface)
+        self.handleIf0.claimInterface(display_interface.interfaceNumber)
         logger.info("Claimed LCD interface")
         logger.debug("Claiming macro interface")
-        self.handleIf1.claimInterface(macro_and_backlight_interface)
+        self.handleIf1.claimInterface(macro_and_backlight_interface.interfaceNumber)
         logger.info("Claimed macro interface")
         
         if self.enable_mm_keys:


### PR DESCRIPTION
Attributes are no longer iterables/dicts and instead must use the class
.get() method to check if a specific attribute exists. The
claimInterface method of the usb devices expects to receive just the
interface number itself.

Appears original versions of pyusb developed against worked slightly
differently in both terms of attribute access for devices and argument
accepted for identifying interfaces.