### PR TITLE
Fix libimpulse build failure.

### DIFF
--- a/src/libimpulse/Makefile.am
+++ b/src/libimpulse/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libimpulse.la
 libimpulse_la_SOURCES = Impulse.c
 libimpulse_la_CFLAGS = ${PULSE_CFLAGS} ${FFTW_CFLAGS}
-libimpulse_la_LDFLAGS = -version-info 1:0:1 -no-undefined -pthread -shared -Wl ${PULSE_LIBS} ${FFTW_LIBS}, -fPIC
+libimpulse_la_LDFLAGS = -version-info 1:0:1 -no-undefined -pthread -shared -Wl ${PULSE_LIBS} ${FFTW_LIBS} -fPIC
 
 pyexec_LTLIBRARIES = impulse.la
 impulse_la_SOURCES = impulsemodule.c


### PR DESCRIPTION
/usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lfftw3,
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:478: libimpulse.la] Error 1
make[2]: Leaving directory '/var/tmp/portage/app-misc/gnome15-9999/work/gnome15-9999/src/libimpulse'